### PR TITLE
Add support for wrapped formatter hooks

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,6 +35,7 @@ fn build_library() {
             format!("{}/Encoder.c", ZYDIS_SRC_PATH),
             format!("{}/EncoderData.c", ZYDIS_SRC_PATH),
             format!("{}/Formatter.c", ZYDIS_SRC_PATH),
+            format!("{}/FormatHelper.c", ZYDIS_SRC_PATH),
             format!("{}/Mnemonic.c", ZYDIS_SRC_PATH),
             format!("{}/Register.c", ZYDIS_SRC_PATH),
             format!("{}/SharedData.c", ZYDIS_SRC_PATH),

--- a/examples/formatter_hooks.rs
+++ b/examples/formatter_hooks.rs
@@ -1,0 +1,27 @@
+extern crate zydis;
+use zydis::gen::*;
+use zydis::*;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+static CODE: &'static [u8] = &[
+    0x51, 0x8D, 0x45, 0xFF, 0x50, 0xFF, 0x75, 0x0C, 0xFF, 0x75, 0x08,
+    0xFF, 0x15, 0xA0, 0xA5, 0x48, 0x76, 0x85, 0xC0, 0x0F, 0x88, 0xFC,
+    0xDA, 0x02, 0x00u8,
+];
+
+fn print_mnemonic(formatter: &Formatter, buffer: &mut Buffer, instruction: &ZydisDecodedInstruction) -> ZydisResult<()> {
+    buffer.append("abc");
+    Ok(())
+}
+
+fn main() {
+    let mut formatter = Formatter::new(ZYDIS_FORMATTER_STYLE_INTEL).unwrap();
+    formatter.set_print_mnemonic(Box::new(print_mnemonic)).unwrap();
+
+    let decoder = Decoder::new(ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_ADDRESS_WIDTH_64).unwrap();
+
+    for (mut instruction, ip) in decoder.instruction_iterator(CODE, 0) {
+        let insn = formatter.format_instruction(&mut instruction, 200);
+        println!("0x{:016X} {}", ip, insn.unwrap());
+    }
+}

--- a/examples/formatter_hooks.rs
+++ b/examples/formatter_hooks.rs
@@ -10,12 +10,11 @@ static CODE: &'static [u8] = &[
 ];
 
 fn print_mnemonic(
-    formatter: &Formatter,
+    _formatter: &Formatter,
     buffer: &mut Buffer,
-    instruction: &ZydisDecodedInstruction,
+    _instruction: &ZydisDecodedInstruction,
 ) -> ZydisResult<()> {
-    buffer.append("abc");
-    Ok(())
+    buffer.append("abc")
 }
 
 fn main() {

--- a/examples/formatter_hooks.rs
+++ b/examples/formatter_hooks.rs
@@ -9,14 +9,20 @@ static CODE: &'static [u8] = &[
     0xDA, 0x02, 0x00u8,
 ];
 
-fn print_mnemonic(formatter: &Formatter, buffer: &mut Buffer, instruction: &ZydisDecodedInstruction) -> ZydisResult<()> {
+fn print_mnemonic(
+    formatter: &Formatter,
+    buffer: &mut Buffer,
+    instruction: &ZydisDecodedInstruction,
+) -> ZydisResult<()> {
     buffer.append("abc");
     Ok(())
 }
 
 fn main() {
     let mut formatter = Formatter::new(ZYDIS_FORMATTER_STYLE_INTEL).unwrap();
-    formatter.set_print_mnemonic(Box::new(print_mnemonic)).unwrap();
+    formatter
+        .set_print_mnemonic(Box::new(print_mnemonic))
+        .unwrap();
 
     let decoder = Decoder::new(ZYDIS_MACHINE_MODE_LONG_64, ZYDIS_ADDRESS_WIDTH_64).unwrap();
 

--- a/examples/pattern.rs
+++ b/examples/pattern.rs
@@ -26,14 +26,12 @@ fn main() {
 
             // Obtain offsets for relevant operands, skip others.
             let (dyn_offs, dyn_len) = match op.type_ as ZydisOperandTypes {
-                ZYDIS_OPERAND_TYPE_MEMORY if op.mem.disp.hasDisplacement == 1 => (
-                    insn.raw.disp.offset,
-                    insn.raw.disp.size,
-                ),
-                ZYDIS_OPERAND_TYPE_IMMEDIATE if op.imm.isRelative == 1 => (
-                    insn.raw.imm[op_idx].offset,
-                    insn.raw.imm[op_idx].size,
-                ),
+                ZYDIS_OPERAND_TYPE_MEMORY if op.mem.disp.hasDisplacement == 1 => {
+                    (insn.raw.disp.offset, insn.raw.disp.size)
+                }
+                ZYDIS_OPERAND_TYPE_IMMEDIATE if op.imm.isRelative == 1 => {
+                    (insn.raw.imm[op_idx].offset, insn.raw.imm[op_idx].size)
+                }
                 _ => continue,
             };
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -51,7 +51,7 @@ impl Decoder {
     ///     zydis::gen::ZYDIS_ADDRESS_WIDTH_64
     /// ).unwrap();
     /// let info = decoder.decode(INT3, 0x00400000).unwrap().unwrap();
-    /// assert_eq!(info.mnemonic as i32, zydis::gen::ZYDIS_MNEMONIC_INT3);
+    /// assert_eq!(info.mnemonic as u32, zydis::gen::ZYDIS_MNEMONIC_INT3);
     /// ```
     pub fn decode(
         &self,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -51,7 +51,7 @@ impl Decoder {
     ///     zydis::gen::ZYDIS_ADDRESS_WIDTH_64
     /// ).unwrap();
     /// let info = decoder.decode(INT3, 0x00400000).unwrap().unwrap();
-    /// assert_eq!(info.mnemonic as u32, zydis::gen::ZYDIS_MNEMONIC_INT3);
+    /// assert_eq!(info.mnemonic as i32, zydis::gen::ZYDIS_MNEMONIC_INT3);
     /// ```
     pub fn decode(
         &self,

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -162,8 +162,10 @@ macro_rules! wrapped_hook_setter{
 
 macro_rules! dispatch_wrapped_func{
     (notify $field_name:ident, $func_name:ident) => {
-        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter,
-                                        instruction: *mut ZydisDecodedInstruction) -> ZydisStatus {
+        unsafe extern "C" fn $func_name(
+            formatter: *const ZydisFormatter,
+            instruction: *mut ZydisDecodedInstruction,
+        ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
             let r = match formatter.$field_name.as_ref().unwrap()(formatter, &*instruction) {
                 Ok(_) => ZYDIS_STATUS_SUCCESS,
@@ -173,13 +175,18 @@ macro_rules! dispatch_wrapped_func{
         }
     };
     (format $field_name:ident, $func_name:ident) => {
-        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char,
-                                        len: usize,
-                                        instruction: *mut ZydisDecodedInstruction) -> ZydisStatus {
+        unsafe extern "C" fn $func_name(
+            formatter: *const ZydisFormatter,
+            buffer: *mut *mut c_char,
+            len: usize,
+            instruction: *mut ZydisDecodedInstruction
+        ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            let r = match formatter.$field_name.as_ref().unwrap()(formatter,
-                                                                  &mut Buffer::new(buffer, len),
-                                                                  &*instruction) {
+            let r = match formatter.$field_name.as_ref().unwrap()(
+                formatter,
+                &mut Buffer::new(buffer, len),
+                &*instruction,
+            ) {
                 Ok(_) => ZYDIS_STATUS_SUCCESS,
                 Err(e) => e,
             };
@@ -187,15 +194,20 @@ macro_rules! dispatch_wrapped_func{
         }
     };
     (format_operand $field_name:ident, $func_name:ident) => {
-        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char,
-                                        len: usize,
-                                        instruction: *mut ZydisDecodedInstruction,
-                                        operand: *mut ZydisDecodedOperand) -> ZydisStatus {
+        unsafe extern "C" fn $func_name(
+            formatter: *const ZydisFormatter,
+            buffer: *mut *mut c_char,
+            len: usize,
+            instruction: *mut ZydisDecodedInstruction,
+            operand: *mut ZydisDecodedOperand,
+        ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            let r = match formatter.$field_name.as_ref().unwrap()(formatter,
-                                                                  &mut Buffer::new(buffer, len),
-                                                                  &*instruction,
-                                                                  &*operand) {
+            let r = match formatter.$field_name.as_ref().unwrap()(
+                formatter,
+                &mut Buffer::new(buffer, len),
+                &*instruction,
+                &*operand,
+            ) {
                 Ok(_) => ZYDIS_STATUS_SUCCESS,
                 Err(e) => e,
             };
@@ -203,17 +215,21 @@ macro_rules! dispatch_wrapped_func{
         }
     };
     (format_decorator $field_name:ident, $func_name:ident) => {
-        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char,
-                                        len: usize,
-                                        instruction: *mut ZydisDecodedInstruction,
-                                        operand: *mut ZydisDecodedOperand,
-                                        decorator: ZydisDecoratorType) -> ZydisStatus {
+        unsafe extern "C" fn $func_name(
+            formatter: *const ZydisFormatter, buffer: *mut *mut c_char,
+            len: usize,
+            instruction: *mut ZydisDecodedInstruction,
+            operand: *mut ZydisDecodedOperand,
+            decorator: ZydisDecoratorType
+        ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            let r = match formatter.$field_name.as_ref().unwrap()(formatter,
-                                                                  &mut Buffer::new(buffer, len),
-                                                                  &*instruction,
-                                                                  &*operand,
-                                                                  decorator) {
+            let r = match formatter.$field_name.as_ref().unwrap()(
+                formatter,
+                &mut Buffer::new(buffer, len),
+                &*instruction,
+                &*operand,
+                decorator,
+            ) {
                 Ok(_) => ZYDIS_STATUS_SUCCESS,
                 Err(e) => e,
             };
@@ -221,17 +237,21 @@ macro_rules! dispatch_wrapped_func{
         }
     };
     (format_address $field_name:ident, $func_name:ident) => {
-        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char,
-                                        len: usize,
-                                        instruction: *mut ZydisDecodedInstruction,
-                                        operand: *mut ZydisDecodedOperand,
-                                        address: u64) -> ZydisStatus {
+        unsafe extern "C" fn $func_name(
+            formatter: *const ZydisFormatter, buffer: *mut *mut c_char,
+            len: usize,
+            instruction: *mut ZydisDecodedInstruction,
+            operand: *mut ZydisDecodedOperand,
+            address: u64,
+        ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            let r = match formatter.$field_name.as_ref().unwrap()(formatter,
-                                                                  &mut Buffer::new(buffer, len),
-                                                                  &*instruction,
-                                                                  &*operand,
-                                                                  address) {
+            let r = match formatter.$field_name.as_ref().unwrap()(
+                formatter,
+                &mut Buffer::new(buffer, len),
+                &*instruction,
+                &*operand,
+                address,
+            ) {
                 Ok(_) => ZYDIS_STATUS_SUCCESS,
                 Err(e) => e,
             };

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -4,7 +4,8 @@ use gen::*;
 use status::ZydisResult;
 use std::mem;
 use std::ffi::CStr;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
+use std::slice;
 
 
 #[derive(Clone)]
@@ -20,7 +21,7 @@ pub enum Hook {
     FuncFormatOperandImm(ZydisFormatterFormatOperandFunc),
     FuncPrintOperandsize(ZydisFormatterFormatOperandFunc),
     FuncPrintSegment(ZydisFormatterFormatOperandFunc),
-    FuncPrintDecorator(ZydisFormatterFormatOperandFunc),
+    FuncPrintDecorator(ZydisFormatterFormatDecoratorFunc),
     FuncPrintDisplacement(ZydisFormatterFormatOperandFunc),
     FuncPrintImmediate(ZydisFormatterFormatOperandFunc),
     FuncPrintAddress(ZydisFormatterFormatAddressFunc),
@@ -92,8 +93,136 @@ impl Hook {
     }
 }
 
+pub struct Buffer {
+    raw: *mut *mut c_char,
+    buffer_length: usize,
+}
+
+impl Buffer {
+    pub fn new(raw: *mut *mut c_char, buffer_length: usize) -> Self {
+        Self {
+            raw,
+            buffer_length,
+        }
+    }
+
+    pub fn append(&mut self, s: &str) -> ZydisResult<()> {
+        let bytes = s.as_bytes();
+        if bytes.len() + 1 >= self.buffer_length {
+            return Err(ZYDIS_STATUS_INSUFFICIENT_BUFFER_SIZE);
+        }
+
+        let slice = unsafe { slice::from_raw_parts_mut(*(self.raw) as *mut u8, self.buffer_length) };
+        (&mut slice[..bytes.len()]).clone_from_slice(bytes);
+        slice[bytes.len()] = '\0' as u8;
+        unsafe { *self.raw = (*self.raw).offset(bytes.len() as _) };
+        Ok(())
+    }
+}
+
+pub type WrappedNotifyFunc = Fn(&Formatter, &ZydisDecodedInstruction) -> ZydisResult<()>;
+pub type WrappedFormatFunc = Fn(&Formatter, &mut Buffer, &ZydisDecodedInstruction) -> ZydisResult<()>;
+pub type WrappedFormatOperandFunc = Fn(&Formatter, &mut Buffer, &ZydisDecodedInstruction, &ZydisDecodedOperand) -> ZydisResult<()>;
+pub type WrappedFormatAddressFunc = Fn(&Formatter, &mut Buffer, &ZydisDecodedInstruction, &ZydisDecodedOperand, u64) -> ZydisResult<()>;
+pub type WrappedFormatDecoratorFunc = Fn(&Formatter, &mut Buffer, &ZydisDecodedInstruction, &ZydisDecodedOperand, ZydisDecoratorType) -> ZydisResult<()>;
+
+macro_rules! wrapped_hook_setter{
+    ($field_name:ident, $field_type:ty, $func_name:ident, $dispatch_func:ident, $constructor:expr) => {
+        pub fn $func_name(&mut self, new_func: Box<$field_type>) -> ZydisResult<Hook> {
+            self.$field_name = Some(new_func);
+            self.set_raw_hook($constructor(Some($dispatch_func)))
+        }
+    }
+}
+
+macro_rules! dispatch_wrapped_func{
+    (notify $field_name:ident, $func_name:ident) => {
+        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, instruction: *mut ZydisDecodedInstruction) -> ZydisStatus {
+            let formatter = &*(formatter as *const Formatter);
+            let r = match formatter.$field_name.as_ref().unwrap()(formatter, &*instruction) {
+                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Err(e) => e,
+            };
+            r as _
+        }
+    };
+    (format $field_name:ident, $func_name:ident) => {
+        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char, len: usize, instruction: *mut ZydisDecodedInstruction) -> ZydisStatus {
+            let formatter = &*(formatter as *const Formatter);
+            let r = match formatter.$field_name.as_ref().unwrap()(formatter, &mut Buffer::new(buffer, len), &*instruction) {
+                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Err(e) => e,
+            };
+            r as _
+        }
+    };
+    (format_operand $field_name:ident, $func_name:ident) => {
+        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char, len: usize, instruction: *mut ZydisDecodedInstruction, operand: *mut ZydisDecodedOperand) -> ZydisStatus {
+            let formatter = &*(formatter as *const Formatter);
+            let r = match formatter.$field_name.as_ref().unwrap()(formatter, &mut Buffer::new(buffer, len), &*instruction, &*operand) {
+                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Err(e) => e,
+            };
+            r as _
+        }
+    };
+    (format_decorator $field_name:ident, $func_name:ident) => {
+        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char, len: usize, instruction: *mut ZydisDecodedInstruction, operand: *mut ZydisDecodedOperand, decorator: ZydisDecoratorType) -> ZydisStatus {
+            let formatter = &*(formatter as *const Formatter);
+            let r = match formatter.$field_name.as_ref().unwrap()(formatter, &mut Buffer::new(buffer, len), &*instruction, &*operand, decorator) {
+                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Err(e) => e,
+            };
+            r as _
+        }
+    };
+    (format_address $field_name:ident, $func_name:ident) => {
+        unsafe extern "C" fn $func_name(formatter: *const ZydisFormatter, buffer: *mut *mut c_char, len: usize, instruction: *mut ZydisDecodedInstruction, operand: *mut ZydisDecodedOperand, address: u64) -> ZydisStatus {
+            let formatter = &*(formatter as *const Formatter);
+            let r = match formatter.$field_name.as_ref().unwrap()(formatter, &mut Buffer::new(buffer, len), &*instruction, &*operand, address) {
+                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Err(e) => e,
+            };
+            r as _
+        }
+    }
+}
+
+dispatch_wrapped_func!(notify pre, dispatch_pre);
+dispatch_wrapped_func!(notify post, dispatch_post);
+dispatch_wrapped_func!(format format_instruction, dispatch_format_instruction);
+dispatch_wrapped_func!(format print_prefixes, dispatch_print_prefixes);
+dispatch_wrapped_func!(format print_mnemonic, dispatch_print_mnemonic);
+dispatch_wrapped_func!(format_operand format_operand_reg, dispatch_format_operand_reg);
+dispatch_wrapped_func!(format_operand format_operand_mem, dispatch_format_operand_mem);
+dispatch_wrapped_func!(format_operand format_operand_ptr, dispatch_format_operand_ptr);
+dispatch_wrapped_func!(format_operand format_operand_imm, dispatch_format_operand_imm);
+dispatch_wrapped_func!(format_operand print_operand_size, dispatch_print_operand_size);
+dispatch_wrapped_func!(format_operand print_segment, dispatch_print_segment);
+dispatch_wrapped_func!(format_decorator print_decorator, dispatch_print_decorator);
+dispatch_wrapped_func!(format_address print_address, dispatch_print_address);
+dispatch_wrapped_func!(format_operand print_displacement, dispatch_print_displacement);
+dispatch_wrapped_func!(format_operand print_immediate, dispatch_print_immediate);
+
+#[repr(C)] // needed, since we cast a *const ZydisFormatter to a *const Formatter and the rust compiler 
+// could reorder the fields if this wasn't #[repr(C)].
 pub struct Formatter {
     formatter: ZydisFormatter,
+    pre: Option<Box<WrappedNotifyFunc>>,
+    post: Option<Box<WrappedNotifyFunc>>,
+    format_instruction: Option<Box<WrappedFormatFunc>>,
+    print_prefixes: Option<Box<WrappedFormatFunc>>,
+    print_mnemonic: Option<Box<WrappedFormatFunc>>,
+    format_operand_reg: Option<Box<WrappedFormatOperandFunc>>,
+    format_operand_mem: Option<Box<WrappedFormatOperandFunc>>,
+    format_operand_ptr: Option<Box<WrappedFormatOperandFunc>>,
+    format_operand_imm: Option<Box<WrappedFormatOperandFunc>>,
+    print_operand_size: Option<Box<WrappedFormatOperandFunc>>,
+    print_segment: Option<Box<WrappedFormatOperandFunc>>,
+    print_decorator: Option<Box<WrappedFormatDecoratorFunc>>,
+    print_address: Option<Box<WrappedFormatAddressFunc>>,
+    print_displacement: Option<Box<WrappedFormatOperandFunc>>,
+    print_immediate: Option<Box<WrappedFormatOperandFunc>>,
 }
 
 impl Formatter {
@@ -116,7 +245,9 @@ impl Formatter {
                     displacement_format as _,
                     immediate_format as _,
                 ),
-                Formatter { formatter }
+                Formatter { formatter, pre: None, post: None, format_instruction: None, print_prefixes: None, print_mnemonic: None, format_operand_reg: None, 
+                format_operand_mem: None, format_operand_ptr: None, format_operand_imm: None, print_operand_size: None, print_segment: None, print_decorator: None,
+                print_address: None, print_displacement: None, print_immediate: None, }
             )
         }
     }
@@ -183,7 +314,7 @@ impl Formatter {
     }
 
     /// Sets a hook, allowing for customizations along the formatting process.
-    pub fn set_hook(&mut self, hook: Hook) -> ZydisResult<Hook> {
+    pub fn set_raw_hook(&mut self, hook: Hook) -> ZydisResult<Hook> {
         unsafe {
             let mut cb = hook.to_raw();
             let hook_id = hook.to_id();
@@ -194,4 +325,20 @@ impl Formatter {
             )
         }
     }
+
+    wrapped_hook_setter!(pre, WrappedNotifyFunc, set_pre, dispatch_pre, Hook::FuncPre);
+    wrapped_hook_setter!(post, WrappedNotifyFunc, set_post, dispatch_post, Hook::FuncPost);
+    wrapped_hook_setter!(format_instruction, WrappedFormatFunc, set_format_instruction, dispatch_format_instruction, Hook::FuncFormatInstruction);
+    wrapped_hook_setter!(print_prefixes, WrappedFormatFunc, set_print_prefixes, dispatch_print_prefixes, Hook::FuncPrintPrefixes);
+    wrapped_hook_setter!(print_mnemonic, WrappedFormatFunc, set_print_mnemonic, dispatch_print_mnemonic, Hook::FuncPrintMnemonic);
+    wrapped_hook_setter!(format_operand_reg, WrappedFormatOperandFunc, set_format_operand_reg, dispatch_format_operand_reg, Hook::FuncFormatOperandReg);
+    wrapped_hook_setter!(format_operand_mem, WrappedFormatOperandFunc, set_format_operand_mem, dispatch_format_operand_mem, Hook::FuncFormatOperandMem);
+    wrapped_hook_setter!(format_operand_ptr, WrappedFormatOperandFunc, set_format_operand_ptr, dispatch_format_operand_ptr, Hook::FuncFormatOperandPtr);
+    wrapped_hook_setter!(format_operand_imm, WrappedFormatOperandFunc, set_format_operand_imm, dispatch_format_operand_imm, Hook::FuncFormatOperandImm);
+    wrapped_hook_setter!(print_operand_size, WrappedFormatOperandFunc, set_print_operand_size, dispatch_print_operand_size, Hook::FuncPrintOperandsize);
+    wrapped_hook_setter!(print_segment, WrappedFormatOperandFunc, set_print_segment, dispatch_print_segment, Hook::FuncPrintSegment);
+    wrapped_hook_setter!(print_decorator, WrappedFormatDecoratorFunc, set_print_decorator, dispatch_print_decorator, Hook::FuncPrintDecorator);
+    wrapped_hook_setter!(print_address, WrappedFormatAddressFunc, set_print_address, dispatch_print_address, Hook::FuncPrintAddress);
+    wrapped_hook_setter!(print_displacement, WrappedFormatOperandFunc, set_print_displacement, dispatch_print_displacement, Hook::FuncPrintDisplacement);
+    wrapped_hook_setter!(print_immediate, WrappedFormatOperandFunc, set_print_immediate, dispatch_print_immediate, Hook::FuncPrintImmediate);
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -93,6 +93,7 @@ impl Hook {
     }
 }
 
+/// Wraps the raw `*mut *mut c_char` of formatter hooks and makes it easier to use.
 pub struct Buffer {
     raw: *mut *mut c_char,
     buffer_length: usize,
@@ -103,6 +104,12 @@ impl Buffer {
         Self { raw, buffer_length }
     }
 
+    /// Appends the given string `s` to this buffer.
+    ///
+    /// Warning: The actual rust `&str`ings are encoded in UTF-8 and they are not
+    /// converted to any other encoding. They're simply copied, byte for byte, to the
+    /// buffer. Therefor the buffer should be interpreted as UTF-8 when later being printed.
+    /// A `\0` is automatically added.
     pub fn append(&mut self, s: &str) -> ZydisResult<()> {
         let bytes = s.as_bytes();
         if bytes.len() + 1 >= self.buffer_length {

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -2,7 +2,6 @@
 
 use gen::*;
 use std::ffi::CStr;
-use std::os::raw::c_uint;
 
 /// Extensions for `ZydisMnemonic`
 pub trait ZydisMnemonicMethods {
@@ -17,7 +16,7 @@ pub trait ZydisMnemonicMethods {
     fn get_string(self) -> Option<&'static str>;
 }
 
-impl ZydisMnemonicMethods for c_uint {
+impl ZydisMnemonicMethods for i32 {
     fn get_string(self) -> Option<&'static str> {
         unsafe { check_string!(ZydisMnemonicGetString(self as _)) }
     }

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -2,6 +2,7 @@
 
 use gen::*;
 use std::ffi::CStr;
+use std::os::raw::c_uint;
 
 /// Extensions for `ZydisMnemonic`
 pub trait ZydisMnemonicMethods {
@@ -16,7 +17,7 @@ pub trait ZydisMnemonicMethods {
     fn get_string(self) -> Option<&'static str>;
 }
 
-impl ZydisMnemonicMethods for i32 {
+impl ZydisMnemonicMethods for c_uint {
     fn get_string(self) -> Option<&'static str> {
         unsafe { check_string!(ZydisMnemonicGetString(self as _)) }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ impl ZydisDecodedInstruction {
         unsafe {
             let mut address = 0u64;
             check!(
-                ZydisUtilsCalcAbsoluteTargetAddress(self, operand, &mut address),
+                ZydisCalcAbsoluteAddress(self, operand, &mut address),
                 address
             )
         }
@@ -22,7 +22,7 @@ impl ZydisDecodedInstruction {
     ) -> ZydisResult<ZydisCPUFlagMask> {
         unsafe {
             let mut code = uninitialized();
-            check!(ZydisGetCPUFlagsByAction(self, action, &mut code), code)
+            check!(ZydisGetAccessedFlagsByAction(self, action, &mut code), code)
         }
     }
 }


### PR DESCRIPTION
These hooks make it easier to actually print things into a Buffer from rust. There are also some bugfixes in this PR, see the first commit message for more detail.