### PR TITLE
Adding get_version function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,22 @@ pub use mnemonic::*;
 pub use register::*;
 pub use status::*;
 pub use utils::*;
+
+/// Returns the version of the zydis C library as a quadruple `(major, minor, patch, build)`
+/// 
+/// # Examples
+/// ```
+/// use zydis;
+/// let (major, minor, patch, build) = zydis::get_version();
+/// println!("Zydis version: {}.{}.{}.{}", major, minor, patch, build);
+/// ```
+pub fn get_version() -> (u16, u16, u16, u16) {
+    let combined_ver = unsafe {
+        gen::ZydisGetVersion()
+    };
+    let major = ((combined_ver << 0) >> 48) as u16;
+    let minor = ((combined_ver << 16) >> 48) as u16;
+    let patch = ((combined_ver << 32) >> 48) as u16;
+    let build = ((combined_ver << 48) >> 48) as u16;
+    (major, minor, patch, build)
+}


### PR DESCRIPTION
Hello all,
The function `ZydisGetVersion` returns a combined value of `(major, minor, patch, build)`. Since [this feature](https://github.com/rust-lang-nursery/rust-bindgen/issues/753) of bindgen is not supported yet, we can not use existing macros, e.g. [ZYDIS_VERSION_MAJOR](https://github.com/zyantific/zydis/blob/master/include/Zydis/Zydis.h#L78) to extract parts of the combined version. The PR allows:

```
let (major, minor, patch, build) = zydis::get_version();
```