### PR TITLE
use rustified_enum for ZydisStatusCodes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,7 @@ fn build_bindings(out_path: PathBuf) {
         .clang_arg(format!("-I{}", ZYDIS_INCLUDE_PATH))
         .clang_arg(format!("-I{}", ZYDIS_SRC_PATH))
         .clang_arg("-Isrc")
+        .rustified_enum("ZydisStatusCodes")
         // Seems to be broken, layout tests are failing because of this type.
         .blacklist_type("max_align_t");
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -220,15 +220,15 @@ macro_rules! wrap_func {
             user_data: *mut c_void,
         ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            match formatter.$field_name.as_ref().unwrap()(
+            ZydisStatus::from(match formatter.$field_name.as_ref().unwrap()(
                 formatter,
                 &mut *string,
                 &*instruction,
                 get_user_data!(user_data),
             ) {
-                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Ok(_) => ZydisStatusCodes::ZYDIS_STATUS_SUCCESS,
                 Err(e) => e.get_code(),
-            }
+            })
         }
     };
     (operand $field_name:ident, $func_name:ident) => {
@@ -240,16 +240,16 @@ macro_rules! wrap_func {
             user_data: *mut c_void,
         ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            match formatter.$field_name.as_ref().unwrap()(
+            ZydisStatus::from(match formatter.$field_name.as_ref().unwrap()(
                 formatter,
                 &mut *string,
                 &*instruction,
                 &*operand,
                 get_user_data!(user_data),
             ) {
-                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Ok(_) => ZydisStatusCodes::ZYDIS_STATUS_SUCCESS,
                 Err(e) => e.get_code(),
-            }
+            })
         }
     };
     (register $field_name:ident, $func_name:ident) => {
@@ -262,7 +262,7 @@ macro_rules! wrap_func {
             user_data: *mut c_void,
         ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            match formatter.$field_name.as_ref().unwrap()(
+            ZydisStatus::from(match formatter.$field_name.as_ref().unwrap()(
                 formatter,
                 &mut *string,
                 &*instruction,
@@ -270,9 +270,9 @@ macro_rules! wrap_func {
                 reg,
                 get_user_data!(user_data),
             ) {
-                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Ok(_) => ZydisStatusCodes::ZYDIS_STATUS_SUCCESS,
                 Err(e) => e.get_code(),
-            }
+            })
         }
     };
     (address $field_name:ident, $func_name:ident) => {
@@ -285,7 +285,7 @@ macro_rules! wrap_func {
             user_data: *mut c_void,
         ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            match formatter.$field_name.as_ref().unwrap()(
+            ZydisStatus::from(match formatter.$field_name.as_ref().unwrap()(
                 formatter,
                 &mut *string,
                 &*instruction,
@@ -293,9 +293,9 @@ macro_rules! wrap_func {
                 address,
                 get_user_data!(user_data),
             ) {
-                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Ok(_) => ZydisStatusCodes::ZYDIS_STATUS_SUCCESS,
                 Err(e) => e.get_code(),
-            }
+            })
         }
     };
     (decorator $field_name:ident, $func_name:ident) => {
@@ -308,7 +308,7 @@ macro_rules! wrap_func {
             user_data: *mut c_void,
         ) -> ZydisStatus {
             let formatter = &*(formatter as *const Formatter);
-            match formatter.$field_name.as_ref().unwrap()(
+            ZydisStatus::from(match formatter.$field_name.as_ref().unwrap()(
                 formatter,
                 &mut *string,
                 &*instruction,
@@ -316,9 +316,9 @@ macro_rules! wrap_func {
                 decorator,
                 get_user_data!(user_data),
             ) {
-                Ok(_) => ZYDIS_STATUS_SUCCESS,
+                Ok(_) => ZydisStatusCodes::ZYDIS_STATUS_SUCCESS,
                 Err(e) => e.get_code(),
-            }
+            })
         }
     };
 }


### PR DESCRIPTION
Hello all,
TL;DR: you may kill me for this PR but let me explain :)

The problem is that when building on Windows, the underlying type of `ZydisStatusCodes` is `i32` (not `u32` as on Linux), this is a [problem](https://github.com/rust-lang-nursery/rust-bindgen/issues/1361) (or feature) of MSVC and not bindgen. So types `ZydisStatus` (i.e. `u32`)  and `ZydisStatusCodes` are not any longer compatible.

Adding some simple type casting `as`, but I find this ugly :) so I've chosen the hard way: use rustified enum for `ZydisStatusCodes`. That leads to a verbose fix, but I find it "more rusty" since `ZydisStatusCodes` is bind really to a enum type in Rust.

Feel free to reject it if you aren't agree :(

NB. Other enums can be rustified too (I've managed to do that for all enums of zydis)