### PR TITLE
Fixed: Build in no_std environment

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use alloc::{vec, vec::Vec};
 use crate::{ffi, *};
 use core::{

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+use alloc::{vec, vec::Vec};
 use crate::{ffi, *};
 use core::{
     mem::{self, ManuallyDrop, MaybeUninit},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! - [Format instructions to human-readable text][`Formatter`]
 //! - [Decode, change and re-encode instructions][`EncoderRequest`]
 //! - [Encode new instructions from scratch][`EncoderRequest`]
+extern crate alloc;
 
 #[macro_use]
 mod status;


### PR DESCRIPTION
This simple PR makes it possible to build the library in a `no_std` environment once again.

Although the library itself is `no_std`, it's being tested under an `std` environment; as a result of this, implicit `use`(s) that are automatically imported by std apply while building tests, but not while building from an actual `no_std` environment.

In this case, we needed to specify the imports from `alloc` manually.