### PR TITLE
Fix typo in error message (undfined)

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -95,7 +95,7 @@ impl Status {
             }
             Status::DecodingError => {
                 "An general error occured while decoding the current instruction. The instruction \
-                 might be undfined."
+                 might be undefined."
             }
             Status::InstructionTooLong => {
                 "The instruction exceeded the maximum length of 15 bytes."


### PR DESCRIPTION
I hope it is alright for me to submit such a small pull request :)

This fixes a typo in the error message for Status::DecodingError: undfined -> undefined.